### PR TITLE
passed context down to store client

### DIFF
--- a/lib/store.js
+++ b/lib/store.js
@@ -54,7 +54,7 @@ Store.prototype.get = function *(sid) {
   return data;
 };
 
-Store.prototype.set = function *(sid, sess) {
+Store.prototype.set = function *(sid, sess, ctx) {
   var ttl = this.options.ttl;
   if (!ttl) {
     var maxage = sess.cookie && sess.cookie.maxage;
@@ -69,7 +69,7 @@ Store.prototype.set = function *(sid, sess) {
 
   sid = this.options.prefix + sid;
   debug('SET key: %s, value: %s, ttl: %d', sid, sess, ttl);
-  yield this.client.set(sid, sess, ttl);
+  yield this.client.set(sid, sess, ttl, ctx);
   debug('SET complete');
 };
 


### PR DESCRIPTION
We need the koa context to reach the custom session store so that the latter has the option to extract information such as agent, IP, etc
